### PR TITLE
#60 - 대댓글 도메인 설계

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -4,7 +4,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -25,17 +28,33 @@ public class ArticleComment extends AuditingFields {
     @Setter
     @ManyToOne(optional = false)
     @JoinColumn(name="userId") private UserAccount userAccount; // 유저 정보 (ID)
+
+    @Setter
+    @Column(nullable = true, updatable = false)
+    private Long parentCommentId; // 부모 댓글 번호
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>(); // 자식 댓글
+
     @Setter @Column(nullable = false, length = 500) private String content; // 댓글 내용
 
     protected ArticleComment() {}
 
     public static ArticleComment of(Article article, UserAccount userAccount, String content) {
-        return new ArticleComment(article, userAccount, content);
+        return new ArticleComment(article, userAccount, null, content);
     }
-    private ArticleComment(Article article, UserAccount userAccount, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, Long parentCommentId, String content) {
         this.article = article;
         this.userAccount = userAccount;
+        this.parentCommentId = parentCommentId;
         this.content = content;
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.getId());
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
대댓글 도메인 안에서 부모, 자식 관계를 설정하는 코드를 추가.
자식 댓글의 컬렉션 변화가 쿼리에 반영되게끔 cascading 규칙을 ALL로 적용
이번엔 단방향 연관관계 설정을 사용해보기로 했음.
따라서 부모 댓글은 엔티티가 아닌 `Long` id로 직접 표현

또한 자식 댓글을 추가할 수 있는 메소드 추가 제공.

1차 대댓글 도메인 업데이트.

This closes #60 