### PR TITLE
#74 - 로그인 버그 수정

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/error").permitAll()
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/",


### PR DESCRIPTION
`/error`페이지를 permitAll함으로써
에러 페이지가 뜨지 않도록 했다.